### PR TITLE
Number of Coins Total

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -21,7 +21,7 @@ const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT            = 60 * 60 * 2;
 const size_t   BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW             = 60;
 
 const uint64_t MONEY_SUPPLY                                  = ((uint64_t)(-1));  // ((uint64_t)(-1)) equals to 18446744073709551616 coins
-const uint64_t COIN_SIZE                                     = ((uint64_t)100000000000) // 10^9 = 184M total coins
+const uint64_t COIN                                     = ((uint64_t)100000000000) // 10^9 = 184M total coins
 const unsigned EMISSION_SPEED_FACTOR                         = 18;
 static_assert(EMISSION_SPEED_FACTOR <= 8 * sizeof(uint64_t), "Bad EMISSION_SPEED_FACTOR");
 

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -15,16 +15,13 @@ const size_t   CRYPTONOTE_MAX_BLOCK_BLOB_SIZE                = 500000000;
 const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
 //TODO Currency-specific address prefix
 const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 0x19;  // Addresses will start with p
-//TODO Choose maturity period for your currency
 const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 60;
 const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT            = 60 * 60 * 2;
 
 const size_t   BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW             = 60;
 
-//TODO Specify total number of available coins
-//TODO ((uint64_t)(-1)) equals to 18446744073709551616 coins
-//TODO or you can define number explicitly UINT64_C(858986905600000000)
-const uint64_t MONEY_SUPPLY                                  = ((uint64_t)(-1));
+const uint64_t MONEY_SUPPLY                                  = ((uint64_t)(-1));  // ((uint64_t)(-1)) equals to 18446744073709551616 coins
+const uint64_t COIN_SIZE                                     = ((uint64_t)100000000000) // 10^9 = 184M total coins
 const unsigned EMISSION_SPEED_FACTOR                         = 18;
 static_assert(EMISSION_SPEED_FACTOR <= 8 * sizeof(uint64_t), "Bad EMISSION_SPEED_FACTOR");
 
@@ -32,8 +29,7 @@ static_assert(EMISSION_SPEED_FACTOR <= 8 * sizeof(uint64_t), "Bad EMISSION_SPEED
 const size_t   CRYPTONOTE_REWARD_BLOCKS_WINDOW               = 100;
 const size_t   CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE     = 10000; //size of block (bytes) after which reward for block calculated using block size
 const size_t   CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE        = 600;
-//TODO Define number of digits
-const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 8;
+const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 14;
 //TODO Define minimum fee for transactions
 const uint64_t MINIMUM_FEE                                   = 100000;
 const uint64_t DEFAULT_DUST_THRESHOLD                        = MINIMUM_FEE;


### PR DESCRIPTION
I think we should keep the total mined as the biggest 64-bit int because this gives us the most precision and is the tested default.  I think we should think of each pollen as 10^9 atomic units, so there will be 184M total coins.  This matches this analysis: https://docs.google.com/spreadsheets/d/1TAascOuYzjkJh3R2ZVKZp8e6aD5cMWJ6MmXRLd36cR0/edit#gid=0

Note: the COIN const is not used in code rn but is immortalized for reference.

Displayed digits set to 14.  Monero + 2